### PR TITLE
roadmap: NMControl: remove "new DNS server"; add "release"

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -38,8 +38,8 @@ __bold__ : important
         - Semi-safe SPV via merkle tree and blockheaders
         - SPV
     - NMControl
+        - __Release__
         - TLS
-            - new DNS server
         - API mode (experimental version works)
         - Tor support (__TBD__)
         - Tor browser support (__TBD__)


### PR DESCRIPTION
I don't see the new DNS server coming in NMControl anytime soon. Also it should probably not sit under TLS.
